### PR TITLE
Fix broken link

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,9 +17,9 @@
     "accessibility",
     "contrast"
   ],
-  "homepage": "https://github.com/nathsimpson/hex-ally",
+  "homepage": "https://github.com/nathsimpson/hex-a11y",
   "bugs": {
-    "url": "https://github.com/nathsimpson/hex-ally/issues"
+    "url": "https://github.com/nathsimpson/hex-a11y/issues"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
Hey there, thanks for this package!

It seems there is a broken link on https://www.npmjs.com/package/hex-a11y :

![Screen Shot 2022-05-21 at 16 51 40](https://user-images.githubusercontent.com/1935696/169656996-11405c65-1ab4-4757-a453-2b5cf52f10c9.png)

This is a quick PR to fix it.

It will require a new publish to npm to fix the link 
